### PR TITLE
remove sourcing and call rbenv init directly

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -113,15 +113,9 @@ echo "==> Adding Ruby version auto-switching to .bash_profile/.zshrc…"
 
 if [[ -f ~/.bash_profile ]]; then
   grep -qF -- 'eval "$(rbenv init -)"' ~/.bash_profile || echo '\n# rbenv ruby version auto-switching - inserted by @hoverinc\neval "$(rbenv init -)"' >> ~/.bash_profile
-  set +e
-  source ~/.bash_profile
-  set -e
 fi
 if [[ -f ~/.zshrc ]]; then
   grep -qF -- 'eval "$(rbenv init -)"' ~/.zshrc || echo '\n# rbenv ruby version auto-switching - inserted by @hoverinc\neval "$(rbenv init -)"' >> ~/.zshrc
-  set +e
-  source ~/.zshrc
-  set -e
 fi
 echo
 
@@ -129,6 +123,8 @@ echo
 set +e
 source ~/.bash_profile
 set -e
+
+rbenv init
 
 # Install Bundler
 echo "==> Installing the Bundler Ruby gem…"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -119,12 +119,10 @@ if [[ -f ~/.zshrc ]]; then
 fi
 echo
 
-# Re-source the .bash_profile for current user
-set +e
-source ~/.bash_profile
-set -e
-
+# Initialize rbenv in this shell for use
+echo "==> Initializing rbenv…"
 rbenv init
+echo
 
 # Install Bundler
 echo "==> Installing the Bundler Ruby gem…"


### PR DESCRIPTION
sourcing zshrc will fail since the script is likely to be running in bash
simpler solution might be just to call rbenv init directly