### PR TITLE
remove hub

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -14,7 +14,6 @@ brew 'docker-machine-completion'
 brew 'git'
 brew 'graphviz'
 brew 'htop'
-brew 'hub'
 brew 'jq'
 brew 'rbenv'
 brew 'redis', restart_service: :changed

--- a/Brewfile.lock.json
+++ b/Brewfile.lock.json
@@ -226,27 +226,6 @@
           }
         }
       },
-      "hub": {
-        "version": "2.13.0",
-        "bottle": {
-          "cellar": ":any_skip_relocation",
-          "prefix": "/usr/local",
-          "files": {
-            "catalina": {
-              "url": "https://homebrew.bintray.com/bottles/hub-2.13.0.catalina.bottle.1.tar.gz",
-              "sha256": "ecb167b7862314de59c67deb9c8dcbcec17ff78cc949cd7ce8309efb9f269e1e"
-            },
-            "mojave": {
-              "url": "https://homebrew.bintray.com/bottles/hub-2.13.0.mojave.bottle.1.tar.gz",
-              "sha256": "22e8f62a10d5b985760ca626506b32a31c5a8f298df40a0560e034c7193c5bca"
-            },
-            "high_sierra": {
-              "url": "https://homebrew.bintray.com/bottles/hub-2.13.0.high_sierra.bottle.1.tar.gz",
-              "sha256": "b44b83e821252707efd46b4d1b2920b34a540977941061280a148cf90f4b8e1d"
-            }
-          }
-        }
-      },
       "jq": {
         "version": "1.6",
         "bottle": {


### PR DESCRIPTION
installing hub from Homebrew [breaks some bash-completions including git](https://github.com/scop/bash-completion/issues/387#issuecomment-779485030). 

also - it might be nice to replace it with https://github.com/cli/cli ?