### PR TITLE
Workaround for aws-okta disabled

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -7,7 +7,6 @@ tap 'homebrew/services'
 tap 'codefresh-io/cli' # tap Codefresh homebrew repo
 
 brew 'aws-iam-authenticator'
-# brew 'aws-okta'
 brew 'awscli'
 brew 'bash-completion'
 brew 'codefresh'

--- a/Brewfile
+++ b/Brewfile
@@ -7,7 +7,7 @@ tap 'homebrew/services'
 tap 'codefresh-io/cli' # tap Codefresh homebrew repo
 
 brew 'aws-iam-authenticator'
-brew 'aws-okta'
+# brew 'aws-okta'
 brew 'awscli'
 brew 'bash-completion'
 brew 'codefresh'

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -157,6 +157,11 @@ echo
 echo "==> Running hoverinc/engineering Brewfile to install remaining developer tools and various other niceties…"
 curl https://raw.githubusercontent.com/hoverinc/engineering/main/Brewfile | brew bundle --file=-
 
+echo "==> Install aws-okta from older source as it's disabled and will be deprecated"
+curl https://raw.githubusercontent.com/Homebrew/homebrew-core/bafe9b47dedba4fa19369167fe3363ac5bfcc97c/Formula/aws-okta.rb > $(find $(brew --repository) -name aws-okta.rb | head -n 1)
+brew install aws-okta
+echo
+
 # Cleanup Homebrew packages
 brew cleanup
 echo


### PR DESCRIPTION
### Summary

`aws-okta` package have been disabled in homebrew and can no longer be installed. 

### Steps to reproduce

run `brew install aws-okta`

### What is the current bug behavior?

Shell returns `Error: aws-okta has been disabled because it is deprecated upstream!` when trying to install aws-okta

### Proposed solution

added to script a command to get the `aws-okta.rb` file from an older commit in homebrew repository and use it.