### PR TITLE
update readme and bootstrap script

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ You'll be asked for your:
 - Installs NVM, the latest Node, and the latest NPM
 - Installs Postgres
 
+
+## AWS Credentials
+Follow instructions on this page [Installing gimme-aws-credentials](https://hoverinc.atlassian.net/wiki/spaces/EN/pages/2790850693/Installing+gimme-aws-credentials) to set up your aws credentials
+
 ## Bundler Setup
 
 We use [GitHub Package Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-rubygems-registry) for private repo RubyGems which requires a personal access token.
@@ -62,13 +66,13 @@ We use [GitHub Package Registry](https://docs.github.com/en/packages/working-wit
 10. You should now be able run `bundle install` in a new `Terminal.app` tab/window
 
 * NOTE: If you encounter an error that says the following while running `bundle install`:
-        
+
   ```
   Bad username or password for https://<TOKEN>@rubygems.pkg.github.com/hoverinc/.
   Please double-check your credentials and correct them.
   ```
 
-* Run the following command: 
+* Run the following command:
   ```
   bundle config https://rubygems.pkg.github.com/hoverinc <GITHUB-USERNAME>:<TOKEN>
   ```

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -163,11 +163,6 @@ echo
 echo "==> Running hoverinc/engineering Brewfile to install remaining developer tools and various other niceties…"
 curl https://raw.githubusercontent.com/hoverinc/engineering/main/Brewfile | brew bundle --file=-
 
-echo "==> Install aws-okta from older source as it's disabled and will be deprecated"
-curl https://raw.githubusercontent.com/Homebrew/homebrew-core/bafe9b47dedba4fa19369167fe3363ac5bfcc97c/Formula/aws-okta.rb > $(find $(brew --repository) -name aws-okta.rb | head -n 1)
-brew install aws-okta
-echo
-
 # Cleanup Homebrew packages
 brew cleanup
 echo


### PR DESCRIPTION
updating the readme and bootstrap script:

`aws-okta` step of script no working because it's deprecated. the new way going forward to get aws credentials is in the added link for `gimme aws`, now in the read me as part of the set up instructions

https://hoverinc.slack.com/archives/C087LSXQS/p1684362105066159