### PR TITLE
[DEVOPS-3695] remove codefresh

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -4,12 +4,10 @@ tap 'homebrew/cask'
 tap 'homebrew/cask-fonts'
 tap 'homebrew/core'
 tap 'homebrew/services'
-tap 'codefresh-io/cli' # tap Codefresh homebrew repo
 
 brew 'aws-iam-authenticator'
 brew 'awscli'
 brew 'bash-completion'
-brew 'codefresh'
 brew 'docker-completion'
 brew 'docker-credential-helper'
 brew 'gh'


### PR DESCRIPTION
We no longer use codefresh, so we shouldn't set it up.