### PR TITLE
Added a minor wording change to specify (classic)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Follow instructions on this page [Installing gimme-aws-credentials](https://hove
 We use [GitHub Package Registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-rubygems-registry) for private repo RubyGems which requires a personal access token.
 
 1. Go to [Settings › Developer Settings › Personal access tokens](https://github.com/settings/tokens)
-2. Click on **Generate new token**
+2. Click on **Generate new token (classic)**
 3. Set the **Note** field to `HOVER packages`
 4. Set **Expiration** to `90 days`
 5. Check the **repo** and **read:packages** scopes


### PR DESCRIPTION
Github now has 2 options for tokens, and these instructions are using the (classic) version

Added the single word so future people don't need to do 1 extra click

<img width="329" alt="Screenshot 2024-01-10 at 11 44 41 PM" src="https://github.com/hoverinc/engineering/assets/2624524/6ffb4e37-c1ef-428f-b98c-bc4453cb4920">
