### PR TITLE
Remove unneeded Brew casks

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,8 +1,6 @@
 tap 'buo/cask-upgrade'
 tap 'homebrew/bundle'
-tap 'homebrew/cask'
 tap 'homebrew/cask-fonts'
-tap 'homebrew/core'
 tap 'homebrew/services'
 
 brew 'aws-iam-authenticator'


### PR DESCRIPTION
Just tried bootstrapping a new M2 Mac, and got this error on running `bootstrap` which halted the script:
```
==> Tapping homebrew/bundle
Cloning into '/opt/homebrew/Library/Taps/homebrew/homebrew-bundle'...
remote: Enumerating objects: 7475, done.
remote: Counting objects: 100% (1794/1794), done.
remote: Compressing objects: 100% (283/283), done.
remote: Total 7475 (delta 1565), reused 1665 (delta 1504), pack-reused 5681
Receiving objects: 100% (7475/7475), 1.77 MiB | 9.37 MiB/s, done.
Resolving deltas: 100% (4369/4369), done.
Tapped 1 command (108 files, 2.2MB).
Tapping buo/cask-upgrade
Using homebrew/bundle
Tapping homebrew/cask
Error: Tapping homebrew/cask is no longer typically necessary.
Add --force if you are sure you need it done.
Tapping homebrew/cask has failed!
Tapping homebrew/cask-fonts
Tapping homebrew/core
Error: Tapping homebrew/core is no longer typically necessary.
Add --force if you are sure you need it done.
Tapping homebrew/core has failed!
Using homebrew/services
Installing aws-iam-authenticator
Installing awscli
Installing bash-completion
Installing docker-completion
Installing docker-credential-helper
Installing gh
Using git
Installing github-keygen
Installing graphviz
Installing htop
Installing hub
Installing jq
Installing k9s
Installing kubectl
Installing kubectx
Installing postgresql@14
Using rbenv
Installing redis
Installing watch
Installing yamllint
Installing yq
Homebrew Bundle failed! 2 Brewfile dependencies failed to install.
```
Removing the taps seems to fix it.