### PR TITLE
Update dead link to strap.sh

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,6 +1,5 @@
 tap 'buo/cask-upgrade'
 tap 'homebrew/bundle'
-tap 'homebrew/cask-fonts'
 tap 'homebrew/services'
 
 brew 'aws-iam-authenticator'

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -96,7 +96,7 @@ echo
 
 # Download strap.sh and run it
 echo "==> Downloading strap.sh script from github.com/MikeMcQuaid/strap…"
-curl https://raw.githubusercontent.com/MikeMcQuaid/strap/master/bin/strap.sh -o strap.sh
+curl https://raw.githubusercontent.com/MikeMcQuaid/strap/master/strap.sh -o strap.sh
 echo
 
 echo "==> Strapping your Mac…"
@@ -110,6 +110,8 @@ echo
 
 # Set the Ruby version, same as the .ruby-version file
 ruby_version=`curl https://raw.githubusercontent.com/hoverinc/engineering/main/.ruby-version`
+
+echo "export PATH=/opt/homebrew/bin:$PATH" >> $SHELL_CONFIG
 
 # Update Homebrew and ruby-build to get the latest list of Rubies
 brew update


### PR DESCRIPTION
The path to strap.sh used in bootstrap is no longer valid. This is the closest replacement I could find.

The script was also crashing midway because it was not recognizing the `brew` command.